### PR TITLE
Add remote agent relay mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@
 7. CLI 模式：
   1. `src/cli.rs` 解析 `--tool` / `--input`（或 stdin JSON）
   2. 转发单次工具调用到后台 MCP HTTP 服务 `127.0.0.1:39271/mcp`，打印结果后退出
+8. 远端 Agent 模式：
+  1. `extension/background.js` 在 `chrome.storage.local` 生成并持久化配对 id，通过 `capabilities` 通知发送给 Native Host
+  2. `src/native_host.rs` 收到配对 id 后才让 `src/relay_client.rs` 建立远端连接；debug/test 使用本机 `ws://127.0.0.1:39371/ws`，release 使用 `wss://agent-deck.xianqiao.wang/ws`，客户端在进程内维护 outbox/接收游标并自动重连
+  3. 远端连接使用独立 `Peer` 和 ACP 会话管理器，不会和扩展的请求 id/响应串线
 
 ## 目录职责
 
@@ -75,6 +79,7 @@
 - `src/app_data.rs`：统一解析并创建 `browser4agent` 的跨平台本地应用数据目录；托管 Agent 运行时放在 `agents/`，程序和 ACP 日志放在 `logs/`，安装缓存放在 `npm-cache/`
 - `src/native_messaging.rs`：Native Messaging 基础消息读写
 - `src/peer.rs`：与扩展的双工消息协议（`{ id, method, params }` 请求、`{ id, result | error }` 响应、`{ id, event }` 流事件、无 id 通知），两端对称的 `call` / `handle` / `notify` API
+- `src/relay_client.rs`：Native Host 的远端传输；通过 Git `relay` 依赖复用 wire protocol，配对 id 来自扩展的 `capabilities` 通知；debug/test 连接本机 relay，release 连接 `agent-deck.xianqiao.wang`，在进程内维护 outbox/接收游标并自动重连
 - `src/browser_agent.rs`：浏览器侧 agent 请求协议、会话创建、流式事件转发
 - `src/acp_agent.rs`：共享的长生命周期 ACP connection、持续会话 actor、agent 事件转换
 - `src/acp_agent/catalog.rs`：Claude/Codex/Cursor/pi 的展示信息、用户 CLI 名称及 ACP 启动方式声明
@@ -90,6 +95,7 @@
 - `pnpm --dir extension dev`：开发模式
 - `pnpm lint`：格式化 JS/TS/HTML
 - `cargo build --release`：构建 Native Host
+- `cargo test`：运行 Native Host 的 Rust 测试
 
 ## 维护要求
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -286,8 +287,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -332,6 +335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,8 +368,10 @@ dependencies = [
  "dialoguer",
  "dirs",
  "flate2",
+ "futures-util",
  "jsonc-parser",
  "libc",
+ "relay",
  "reqwest",
  "rmcp",
  "schemars 0.8.22",
@@ -366,6 +380,7 @@ dependencies = [
  "strum 0.27.2",
  "tar",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "winreg",
  "zip",
@@ -423,8 +438,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "rand_core",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -554,6 +569,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -575,6 +599,16 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -609,6 +643,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -694,6 +734,16 @@ dependencies = [
  "shell-words",
  "tempfile",
  "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -783,6 +833,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +881,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -950,6 +1018,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +1042,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -971,8 +1061,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -984,9 +1074,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -1433,6 +1541,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1791,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,7 +1838,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1748,9 +1876,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1760,7 +1904,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1775,7 +1938,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1816,6 +1979,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "relay"
+version = "0.1.0"
+source = "git+https://github.com/mantou132/relay.git#67a44aa5d02a275c30e53ab921a624ee3c27100b"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures-util",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1889,7 +2067,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand",
+ "rand 0.10.2",
  "reqwest",
  "rmcp-macros",
  "schemars 1.2.2",
@@ -1916,6 +2094,31 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2271,6 +2474,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2334,6 +2548,18 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2600,6 +2826,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2698,6 +2940,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +3029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +3064,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2880,6 +3167,24 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3111,6 +3416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,6 +3458,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ tokio-util = "0.7"
 axum = "0.8"
 jsonc-parser = { version = "0.32", features = ["serde"] }
 agent-client-protocol = "1.0.0"
+futures-util = "0.3"
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+relay = { git = "https://github.com/mantou132/relay.git" }
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/extension/background.js
+++ b/extension/background.js
@@ -5,6 +5,7 @@ import { t } from './shared/i18n.js';
 import { loadToolset } from './shared/loader.js';
 import { ensureAuthToken } from './shared/market-api.js';
 import { RpcPeer } from './shared/rpc.js';
+import { localStorageKeys } from './shared/storage-keys.js';
 import { getToolConfig, persist } from './shared/tool-store.js';
 import { getToolsetId } from './shared/toolsets.js';
 import {
@@ -171,16 +172,41 @@ async function updateHostCompat(version) {
   await chrome.action.setTitle({ title: t('hostIncompatTitle') });
 }
 
-peer.onNotify('connected', (params) => {
-  console.log('Connected to native host:', NATIVE_HOST_NAME);
-  updateHostCompat(params?.version).catch((e) => console.error('Failed to check host compat:', e));
-  // Tell the host what this engine supports so it can hide MCP tools the
-  // browser can't serve. Firefox exposes getBrowserInfo; Chromium doesn't.
+let relayIdPromise;
+
+function ensureRelayId() {
+  if (relayIdPromise) return relayIdPromise;
+  relayIdPromise = (async () => {
+    const key = localStorageKeys.relayId;
+    const stored = (await chrome.storage.local.get(key))[key];
+    if (typeof stored === 'string' && stored) return stored;
+    const relayId = crypto.randomUUID();
+    await chrome.storage.local.set({ [key]: relayId });
+    return relayId;
+  })().catch((error) => {
+    relayIdPromise = undefined;
+    throw error;
+  });
+  return relayIdPromise;
+}
+
+async function reportCapabilities() {
+  // Firefox exposes getBrowserInfo; Chromium doesn't.
   const isFirefox = typeof chrome.runtime.getBrowserInfo === 'function';
+  const relayId = await ensureRelayId();
   peer.notify('capabilities', {
     browser: isFirefox ? 'firefox' : 'chromium',
     debuggerAvailable: !isFirefox,
+    relayId,
   });
+}
+
+peer.onNotify('connected', (params) => {
+  console.log('Connected to native host:', NATIVE_HOST_NAME);
+  updateHostCompat(params?.version).catch((e) => console.error('Failed to check host compat:', e));
+  // Tell the host what this engine supports and provide the stable pairing id
+  // before the host starts its optional relay connection.
+  reportCapabilities().catch((e) => console.error('Failed to report capabilities:', e));
   // A (re)connected host process knows no live sessions; panels must drop
   // their cached state.
   agentSessionOwners.clear();

--- a/extension/shared/storage-keys.js
+++ b/extension/shared/storage-keys.js
@@ -5,6 +5,7 @@ const keys = {
   toolStates: 'toolStates',
   likedToolsets: 'likedToolsets',
   agentPanelState: 'browser4agent.agentPanelState.v2',
+  relayId: 'browser4agent.relayId.v1',
 };
 
 const values = Object.values(keys);

--- a/src/acp_agent.rs
+++ b/src/acp_agent.rs
@@ -14,9 +14,9 @@ use agent_client_protocol::{
         ProtocolVersion,
         v1::{
             CancelNotification, CloseSessionRequest, ContentBlock, ContentChunk,
-            DeleteSessionRequest, ImageContent, InitializeRequest, LoadSessionRequest,
-            NewSessionRequest, NewSessionResponse, PermissionOptionId, PromptRequest,
-            PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
+            DeleteSessionRequest, ImageContent, InitializeRequest, ListSessionsRequest,
+            LoadSessionRequest, NewSessionRequest, NewSessionResponse, PermissionOptionId,
+            PromptRequest, PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
             RequestPermissionResponse, ResourceLink, SelectedPermissionOutcome, SessionConfigId,
             SessionConfigValueId, SessionId, SessionModeId, SessionNotification, SessionUpdate,
             SetSessionConfigOptionRequest, SetSessionModeRequest, TextContent,
@@ -751,6 +751,30 @@ impl AgentSessionManager {
         };
         let _ = session.tx.send(SessionCommand::Close).await;
         true
+    }
+
+    /// List sessions persisted by an ACP agent (`session/list`). This does not
+    /// create live actors, so remote clients can discover a session first and
+    /// explicitly load it afterwards.
+    pub async fn list_sessions(
+        &self,
+        agent: &str,
+        cwd: Option<PathBuf>,
+        cursor: Option<String>,
+    ) -> Result<serde_json::Value> {
+        let connection = self.runtime(agent)?.connection().await?;
+        let mut request = ListSessionsRequest::new();
+        if let Some(cwd) = cwd {
+            request = request.cwd(cwd);
+        }
+        if let Some(cursor) = cursor {
+            request = request.cursor(cursor);
+        }
+        let response = connection
+            .send_request_to(Agent, request)
+            .block_task()
+            .await?;
+        Ok(to_json(response))
     }
 
     pub async fn delete_session(&self, agent: &str, session_id: &str) -> Result<()> {

--- a/src/browser_agent.rs
+++ b/src/browser_agent.rs
@@ -186,6 +186,31 @@ pub fn register(peer: &Peer) {
         }
     });
 
+    let list_sessions = sessions.clone();
+    peer.handle("agent_session_list", move |params, _ctx| {
+        let sessions = list_sessions.clone();
+        async move {
+            let agent = required_agent(&params, "agent_session_list")?;
+            let cwd = message_cwd(&params);
+            let cursor = params
+                .get("cursor")
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string);
+            let timeout_secs = message_timeout_secs(&params);
+            match tokio::time::timeout(
+                Duration::from_secs(timeout_secs),
+                sessions.list_sessions(agent, cwd, cursor),
+            )
+            .await
+            {
+                Ok(Ok(list)) => Ok(list),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(_) => Err("Timeout listing ACP agent sessions".to_string()),
+            }
+        }
+    });
+
     let delete_sessions = sessions.clone();
     peer.handle("agent_session_delete", move |params, _ctx| {
         let sessions = delete_sessions.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod native_host;
 mod native_message_setup;
 mod native_messaging;
 mod peer;
+mod relay_client;
 mod skill_setup;
 
 use std::{env, ffi::OsString};

--- a/src/native_host.rs
+++ b/src/native_host.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use rmcp::transport::streamable_http_server::{
@@ -12,12 +12,16 @@ use crate::{
     mcp_server::{BrowserMcpServer, Capabilities, SharedCapabilities},
     native_messaging::read_native_message,
     peer::Peer,
+    relay_client,
 };
 
 /// Run the native messaging loop on the current thread.
 /// Returns when stdin is closed (browser disconnected).
 async fn native_message_loop(peer: Peer) {
-    peer.notify("connected", serde_json::json!({ "version": env!("CARGO_PKG_VERSION") }));
+    peer.notify(
+        "connected",
+        serde_json::json!({ "version": env!("CARGO_PKG_VERSION") }),
+    );
     logger::info("Connected to browser extension");
 
     loop {
@@ -36,11 +40,32 @@ pub async fn run() -> Result<()> {
     browser_agent::register(&peer);
 
     let caps: SharedCapabilities = Arc::default();
+    let remote_peer: Arc<Mutex<Option<Peer>>> = Arc::default();
     {
         let caps = caps.clone();
+        let remote_peer = remote_peer.clone();
         // The extension reports this right after receiving `connected`.
         peer.on_notify("capabilities", move |params| {
             *caps.lock().expect("lock poisoned") = Capabilities::from_params(&params);
+            let Some(relay_id) = params
+                .get("relayId")
+                .and_then(serde_json::Value::as_str)
+                .filter(|id| !id.is_empty())
+            else {
+                return;
+            };
+
+            // The remote peer owns a separate RPC id space and Agent session
+            // manager. Start it only after the extension supplies its stable
+            // pairing id, and retain it for this process's lifetime.
+            let mut remote_peer = remote_peer.lock().expect("lock poisoned");
+            if remote_peer.is_some() {
+                return;
+            }
+            match relay_client::start(relay_id) {
+                Ok(peer) => *remote_peer = Some(peer),
+                Err(error) => logger::info(&format!("Remote relay disabled: {error:#}")),
+            }
         });
     }
 

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -28,6 +28,7 @@ impl CallCtx {
 
 type Handler =
     Arc<dyn Fn(Value, CallCtx) -> BoxFuture<'static, Result<Value, String>> + Send + Sync>;
+type Writer = Arc<dyn Fn(Value) + Send + Sync>;
 
 struct Pending {
     reply: oneshot::Sender<Result<Value, String>>,
@@ -44,15 +45,42 @@ struct Pending {
 ///
 /// Both sides use the same API: `call` / `notify` to initiate,
 /// `handle` / `on_notify` to serve.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Peer {
     pending: Arc<Mutex<HashMap<String, Pending>>>,
     handlers: Arc<Mutex<HashMap<String, Handler>>>,
     notify_handlers: Arc<Mutex<HashMap<String, Arc<dyn Fn(Value) + Send + Sync>>>>,
     next_id: Arc<Mutex<u64>>,
+    writer: Writer,
+}
+
+impl Default for Peer {
+    fn default() -> Self {
+        Self::new(write_native_message)
+    }
 }
 
 impl Peer {
+    /// Create an RPC peer whose outgoing frames use the supplied transport.
+    /// Each transport must have its own `Peer`, keeping request ids and replies
+    /// isolated even when several clients control the same native host.
+    pub fn new<F>(writer: F) -> Self
+    where
+        F: Fn(&Value) + Send + Sync + 'static,
+    {
+        Self {
+            pending: Arc::default(),
+            handlers: Arc::default(),
+            notify_handlers: Arc::default(),
+            next_id: Arc::default(),
+            writer: Arc::new(move |message| writer(&message)),
+        }
+    }
+
+    fn write(&self, message: Value) {
+        (self.writer)(message);
+    }
+
     /// Call the peer and await its final result.
     pub async fn call(&self, method: &str, params: Value) -> Result<Value> {
         self.call_stream(method, params, None).await
@@ -79,7 +107,7 @@ impl Peer {
             },
         );
 
-        write_native_message(&json!({ "id": id, "method": method, "params": params }));
+        self.write(json!({ "id": id, "method": method, "params": params }));
 
         match rx.await {
             Ok(result) => result.map_err(anyhow::Error::msg),
@@ -89,7 +117,7 @@ impl Peer {
 
     /// Send a fire-and-forget notification to the peer.
     pub fn notify(&self, method: &str, params: Value) {
-        write_native_message(&json!({ "method": method, "params": params }));
+        self.write(json!({ "method": method, "params": params }));
     }
 
     /// Register an async handler for requests from the peer. The handler's
@@ -157,24 +185,24 @@ impl Peer {
             .get(&method)
             .cloned();
         let Some(handler) = handler else {
-            write_native_message(
-                &json!({ "id": id, "error": format!("Unknown method: {method}") }),
-            );
+            self.write(json!({ "id": id, "error": format!("Unknown method: {method}") }));
             return;
         };
 
         let emit_id = id.clone();
+        let event_peer = self.clone();
         let ctx = CallCtx {
             emit: Arc::new(move |event| {
-                write_native_message(&json!({ "id": emit_id, "event": event }));
+                event_peer.write(json!({ "id": emit_id, "event": event }));
             }),
         };
+        let reply_peer = self.clone();
         tokio::spawn(async move {
             let reply = match handler(params, ctx).await {
                 Ok(result) => json!({ "id": id, "result": result }),
                 Err(err) => json!({ "id": id, "error": err }),
             };
-            write_native_message(&reply);
+            reply_peer.write(reply);
         });
     }
 

--- a/src/relay_client.rs
+++ b/src/relay_client.rs
@@ -1,0 +1,303 @@
+use std::{
+    collections::HashSet,
+    process,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use relay::{ClientFrame, Endpoint, ServerFrame};
+use serde_json::Value;
+use tokio::sync::Notify;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+use crate::{browser_agent, logger, peer::Peer};
+
+#[cfg(debug_assertions)]
+const RELAY_URL: &str = "ws://127.0.0.1:39371/ws";
+#[cfg(not(debug_assertions))]
+const RELAY_URL: &str = "wss://agent-deck.xianqiao.wang/ws";
+const MIN_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(25);
+
+fn endpoint_url(relay_id: &str) -> String {
+    format!("{RELAY_URL}?id={relay_id}&endpoint=1")
+}
+
+#[derive(Clone, Debug)]
+struct OutboundMessage {
+    message_id: String,
+    payload: Value,
+}
+
+#[derive(Debug)]
+struct ClientState {
+    message_prefix: String,
+    next_message: u64,
+    last_received: Option<u64>,
+    outbox: Vec<OutboundMessage>,
+}
+
+impl ClientState {
+    fn new() -> Result<Self> {
+        let started_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .context("system clock is before the Unix epoch")?
+            .as_nanos();
+        Ok(Self {
+            message_prefix: format!("{started_at:x}-{:x}", process::id()),
+            next_message: 0,
+            last_received: None,
+            outbox: Vec::new(),
+        })
+    }
+}
+
+struct MemoryOutbox {
+    state: Mutex<ClientState>,
+    changed: Notify,
+}
+
+impl MemoryOutbox {
+    fn new() -> Result<Arc<Self>> {
+        Ok(Arc::new(Self {
+            state: Mutex::new(ClientState::new()?),
+            changed: Notify::new(),
+        }))
+    }
+
+    fn enqueue(&self, payload: &Value) {
+        let result = (|| -> Result<()> {
+            let mut state = self.state.lock().expect("relay state lock poisoned");
+            state.next_message = state
+                .next_message
+                .checked_add(1)
+                .context("relay client message id space exhausted")?;
+            let message_id = format!("{}-{}", state.message_prefix, state.next_message);
+            state.outbox.push(OutboundMessage {
+                message_id,
+                payload: payload.clone(),
+            });
+            Ok(())
+        })();
+        if let Err(error) = result {
+            logger::info(&format!("Failed to queue relay message: {error:#}"));
+        }
+        self.changed.notify_one();
+    }
+
+    fn pending(&self) -> Vec<OutboundMessage> {
+        self.state
+            .lock()
+            .expect("relay state lock poisoned")
+            .outbox
+            .clone()
+    }
+
+    fn mark_stored(&self, message_id: &str) {
+        let mut state = self.state.lock().expect("relay state lock poisoned");
+        state
+            .outbox
+            .retain(|message| message.message_id != message_id);
+    }
+
+    fn last_received(&self) -> Option<u64> {
+        self.state
+            .lock()
+            .expect("relay state lock poisoned")
+            .last_received
+    }
+
+    fn mark_received(&self, sequence: u64) {
+        let mut state = self.state.lock().expect("relay state lock poisoned");
+        state.last_received = Some(sequence);
+    }
+}
+
+/// Start the remote RPC transport with the pairing id supplied by the
+/// extension. The service endpoint is the built-in local relay URL.
+pub fn start(relay_id: &str) -> Result<Peer> {
+    validate_relay_id(relay_id)?;
+    let outbox = MemoryOutbox::new()?;
+    let writer_outbox = outbox.clone();
+    let peer = Peer::new(move |message| writer_outbox.enqueue(message));
+    browser_agent::register(&peer);
+    tokio::spawn(run(relay_id.to_string(), outbox, peer.clone()));
+    Ok(peer)
+}
+
+fn validate_relay_id(relay_id: &str) -> Result<()> {
+    let valid = relay_id.len() == 36
+        && relay_id.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        });
+    anyhow::ensure!(valid, "relay id must be a UUID");
+    Ok(())
+}
+
+fn is_new_sequence(last_received: Option<u64>, sequence: u64) -> Result<bool> {
+    let Some(last_received) = last_received else {
+        // The relay sequence is durable but this client's cursor is not. A new
+        // process therefore adopts the first pending sequence as its baseline.
+        return Ok(true);
+    };
+    if sequence <= last_received {
+        return Ok(false);
+    }
+    let expected = last_received
+        .checked_add(1)
+        .context("relay receive sequence space exhausted")?;
+    anyhow::ensure!(
+        sequence == expected,
+        "relay message sequence gap: expected {expected}, received {sequence}"
+    );
+    Ok(true)
+}
+
+enum ConnectionOutcome {
+    Reconnect,
+    Stop,
+}
+
+async fn run(relay_id: String, outbox: Arc<MemoryOutbox>, peer: Peer) {
+    let mut reconnect_delay = MIN_RECONNECT_DELAY;
+    loop {
+        let mut connected = false;
+        match run_connection(&relay_id, &outbox, &peer, &mut connected).await {
+            Ok(ConnectionOutcome::Reconnect) => logger::info("Relay WebSocket disconnected"),
+            Ok(ConnectionOutcome::Stop) => {
+                logger::info(
+                    "Relay connection stopped because this id and endpoint is already connected",
+                );
+                return;
+            }
+            Err(error) => logger::info(&format!("Relay WebSocket error: {error:#}")),
+        }
+        if connected {
+            reconnect_delay = MIN_RECONNECT_DELAY;
+        } else {
+            reconnect_delay = (reconnect_delay * 2).min(MAX_RECONNECT_DELAY);
+        }
+        tokio::time::sleep(reconnect_delay).await;
+    }
+}
+
+async fn run_connection(
+    relay_id: &str,
+    outbox: &Arc<MemoryOutbox>,
+    peer: &Peer,
+    connected: &mut bool,
+) -> Result<ConnectionOutcome> {
+    let url = endpoint_url(relay_id);
+    let (socket, _) = connect_async(&url)
+        .await
+        .with_context(|| format!("failed to connect to relay at {url}"))?;
+    *connected = true;
+    logger::info("Connected to relay WebSocket");
+    let (mut sink, mut stream) = socket.split();
+    let mut sent = HashSet::new();
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + HEARTBEAT_INTERVAL,
+        HEARTBEAT_INTERVAL,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        for message in outbox.pending() {
+            if !sent.insert(message.message_id.clone()) {
+                continue;
+            }
+            send_frame(
+                &mut sink,
+                &ClientFrame::Message {
+                    message_id: message.message_id,
+                    payload: message.payload,
+                },
+            )
+            .await?;
+        }
+
+        tokio::select! {
+            _ = outbox.changed.notified() => {}
+            _ = heartbeat.tick() => {
+                sink.send(Message::Ping(Vec::new().into())).await?;
+            }
+            incoming = stream.next() => {
+                let incoming = incoming.context("relay WebSocket closed")??;
+                let Message::Text(text) = incoming else {
+                    if matches!(incoming, Message::Close(_)) {
+                        return Ok(ConnectionOutcome::Reconnect);
+                    }
+                    continue;
+                };
+                let frame: ServerFrame = serde_json::from_str(&text)
+                    .context("relay returned an invalid frame")?;
+                match frame {
+                    ServerFrame::Ready { endpoint } => {
+                        anyhow::ensure!(
+                            endpoint == Endpoint::One,
+                            "relay connected this client as endpoint {endpoint}"
+                        );
+                    }
+                    ServerFrame::Stored { message_id } => {
+                        outbox.mark_stored(&message_id);
+                        sent.remove(&message_id);
+                    }
+                    ServerFrame::Message { sequence, payload, .. } => {
+                        if is_new_sequence(outbox.last_received(), sequence)? {
+                            peer.dispatch(payload).await;
+                            outbox.mark_received(sequence);
+                        }
+                        send_frame(&mut sink, &ClientFrame::Ack { sequence }).await?;
+                    }
+                    ServerFrame::Error { message } => {
+                        if message.starts_with("connection_conflict:") {
+                            return Ok(ConnectionOutcome::Stop);
+                        }
+                        anyhow::bail!("relay rejected a frame: {message}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn send_frame<S>(sink: &mut S, frame: &ClientFrame) -> Result<()>
+where
+    S: futures_util::Sink<Message> + Unpin,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    let json = serde_json::to_string(frame)?;
+    sink.send(Message::Text(json.into())).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_url_adds_identity_to_built_in_url() {
+        let relay_id = "01234567-89ab-cdef-0123-456789abcdef";
+        assert_eq!(
+            endpoint_url(relay_id),
+            format!("{RELAY_URL}?id={relay_id}&endpoint=1")
+        );
+        assert!(validate_relay_id(relay_id).is_ok());
+        assert!(validate_relay_id("not-a-uuid&endpoint=2").is_err());
+    }
+
+    #[test]
+    fn accepts_any_first_sequence_then_requires_contiguous_messages() {
+        assert!(is_new_sequence(None, 42).unwrap());
+        assert!(is_new_sequence(Some(42), 43).unwrap());
+        assert!(!is_new_sequence(Some(42), 42).unwrap());
+        assert!(is_new_sequence(Some(42), 44).is_err());
+    }
+}


### PR DESCRIPTION
Add `src/relay_client.rs` for remote WebSocket relay transport using the `relay` dependency. Extension generates a pairing id and sends it via `capabilities`. Update AGENTS.md, Cargo.toml, and add `agent_session_list` handler.